### PR TITLE
feat: Validate AI-generated commit type, subject, and body before set…

### DIFF
--- a/src/prompts/BodyPrompt.ts
+++ b/src/prompts/BodyPrompt.ts
@@ -76,7 +76,13 @@ export default class BodyPrompt extends BasePrompt {
     );
 
     // set the commit's body
-    commit.body = await completion.json('body', { value: 'string' }).then(({ value }) => value);
+    commit.body = await completion.text(body => {
+      const [fixed, errors] = this.rules.validate(body);
+
+      if (errors.length) return new Error(errors.join('\n'));
+
+      return fixed;
+    });
   }
 
   async prompt(commit: CommitMessage): Promise<void> {

--- a/src/prompts/SubjectPrompt.ts
+++ b/src/prompts/SubjectPrompt.ts
@@ -31,7 +31,13 @@ export default class SubjectPrompt extends BasePrompt {
     const completion = await this.createAiCompletion().then(completion => completion.user(...contextLines));
 
     // Set the commit's subject, ensuring no type prefix is included
-    const generatedSubject = await completion.text();
+    const generatedSubject = await completion.text(subject => {
+      const [fixed, errors] = this.rules.validate(subject);
+
+      if (errors.length) return new Error(errors.join('\n'));
+
+      return fixed;
+    });
     commit.subject = generatedSubject.replace(/^\w+:\s*/, ''); // Strip any accidental type prefix
   }
 

--- a/src/prompts/TypePrompt.ts
+++ b/src/prompts/TypePrompt.ts
@@ -4,7 +4,7 @@ import type RulesEngine from '../RulesEngine/index.js';
 import BasePrompt from './BasePrompt.js';
 import type Diff from '../services/Git/Diff.js';
 import { red } from 'yoctocolors';
-import CommitMessage from '../CommitMessage/index.js';
+import type CommitMessage from '../CommitMessage/index.js';
 
 export default class TypePrompt extends BasePrompt {
   constructor(rules: RulesEngine) {
@@ -39,14 +39,11 @@ export default class TypePrompt extends BasePrompt {
     );
 
     commit.type = await completion.text(type => {
-      const blankCommit = new CommitMessage();
-      blankCommit.type = type;
-
-      const [errors] = this.rules.validate(blankCommit);
+      const [fixed, errors] = this.rules.validate(type);
 
       if (errors.length) return new Error(errors.join('\n'));
 
-      return type;
+      return fixed;
     });
   }
 


### PR DESCRIPTION
…ting

Add validation for AI-generated commit message components

Introduce validation checks for the commit type, subject, and body generated by the AI completion before setting them on the commit message object. This ensures that the generated values conform to the defined rules and formats, preventing invalid commit messages from being set.

If validation errors are found, an error is returned, prompting the AI to regenerate valid content. This improves the reliability and quality of the automated commit message generation.